### PR TITLE
Mark task complete with checkboxes

### DIFF
--- a/frontend/app/components/task-list-item.js
+++ b/frontend/app/components/task-list-item.js
@@ -4,11 +4,17 @@ export default Ember.Component.extend({
   tagName: 'li',
   classNames: ['task-list-item'],
 
-  actions: {
-    saveTask: function() {
-      var task = this.get('task');
+  // how do I make this not fire uncontrollably?
+  // should it be an action? 
+  updateCompletedStatus: function() {
+    var task = this.get('task');
+
+    if (task.get('completedAt')) {
+      task.set('completedAt', null);
+    } else {
       task.set('completedAt', new Date());
-      task.save();
     }
-  }
+
+    task.save();
+  }.observes('task.isCompleted'),
 });

--- a/frontend/app/models/task.js
+++ b/frontend/app/models/task.js
@@ -3,5 +3,11 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   name: DS.attr('string'),
   completedAt: DS.attr('date'),
-  project: DS.belongsTo('project', { async: true })
+  project: DS.belongsTo('project', { async: true }),
+
+  isCompleted: function() {
+    if (this.get('completedAt')) {
+      return true;
+    }
+  }.property('completedAt')
 });

--- a/frontend/app/templates/components/task-list-item.hbs
+++ b/frontend/app/templates/components/task-list-item.hbs
@@ -1,9 +1,13 @@
-{{task.name}}
-
-{{#if task.completedAt}}
-  Completed
+{{#if task.isCompleted}}
+  {{input type="checkbox"
+    checked=task.isCompleted
+    class="toggle"}}
 {{else}}
   {{#if task.project.canEdit}}
-    <button {{action 'saveTask'}}>Complete</button>
+    {{input type="checkbox"
+      checked=task.isCompleted
+      class="toggle"}}
   {{/if}}
 {{/if}}
+
+{{task.name}}


### PR DESCRIPTION
To use a checkbox input instead of a button, I had to replace the `saveTask` action with an observer on the task's `isCompleted` property because I couldn’t get the checkbox to hit an action. 

However, the observer fires uncontrollably. 

Also, I need to figure out how to change my test now, since it's failing. (Using Ember.Checkbox, there doesn’t
seem to be anything in the markup to differentiate checked from unchecked boxes.  Should I check the completedAt property in the model? Seems wrong to do that in an integration test.)