### PR TITLE
Update project_notes.md

### DIFF
--- a/project_notes.md
+++ b/project_notes.md
@@ -34,7 +34,7 @@
   ```ruby
   # Gemfile
 
-  gem 'active_model_serializers', '0.8.4'
+  gem 'active_model_serializers', '0.8.3'
 
   group :test do
     gem 'shoulda-matchers', require: false


### PR DESCRIPTION
Gem said 0.8.4 instead of 0.8.3 specified above, which gave me console error 
`Could not find gem 'active_model_serializers (= 0.8.4) ruby' in any of the gem
sources listed in your Gemfile or available on this machine.` when I  tried to bundle.
